### PR TITLE
Add Python script to generate project comparison page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # MyTestRepo
+
+This repository contains a simple script to generate a single HTML page comparing project data from Google Sheets.
+
+## Setup
+
+Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Edit `generate_page.py` to set your `SPREADSHEET_CSV_URL` and the column names listed in `PROJECT_COLUMNS`.
+
+Run the script:
+
+```bash
+python generate_page.py
+```
+
+It will create an `output.html` file showing a line graph of the selected projects in a modern, simple page.

--- a/generate_page.py
+++ b/generate_page.py
@@ -1,0 +1,53 @@
+import pandas as pd
+import plotly.express as px
+import plotly.offline as pyo
+
+SPREADSHEET_CSV_URL = "https://docs.google.com/spreadsheets/d/YOUR_SPREADSHEET_ID/export?format=csv"
+
+# Specify columns corresponding to projects in the Google Sheet
+PROJECT_COLUMNS = ["Project A", "Project B"]
+DATE_COLUMN = "Date"
+
+
+def load_data(url: str) -> pd.DataFrame:
+    """Load CSV data from Google Sheets"""
+    return pd.read_csv(url, parse_dates=[DATE_COLUMN])
+
+
+def generate_plot(df: pd.DataFrame) -> str:
+    """Generate a Plotly line chart HTML"""
+    melted = df.melt(id_vars=[DATE_COLUMN], value_vars=PROJECT_COLUMNS, var_name="Project", value_name="Value")
+    fig = px.line(melted, x=DATE_COLUMN, y="Value", color="Project", title="Project Comparison")
+    fig.update_layout(template="plotly_white")
+    return pyo.plot(fig, output_type="div", include_plotlyjs="cdn")
+
+
+def main():
+    data = load_data(SPREADSHEET_CSV_URL)
+    plot_div = generate_plot(data)
+    html = f"""
+    <!DOCTYPE html>
+    <html lang=\"en\">
+    <head>
+        <meta charset=\"UTF-8\">
+        <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
+        <title>Project Comparison</title>
+        <style>
+            body {{ font-family: Arial, sans-serif; margin: 40px; background-color: #f8f9fa; }}
+            h1 {{ text-align: center; }}
+            .chart {{ max-width: 800px; margin: auto; }}
+        </style>
+    </head>
+    <body>
+        <h1>Project Comparison</h1>
+        <div class=\"chart\">{plot_div}</div>
+    </body>
+    </html>
+    """
+    with open("output.html", "w", encoding="utf-8") as f:
+        f.write(html)
+    print("Generated output.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+plotly


### PR DESCRIPTION
## Summary
- add `generate_page.py` to read project data from Google Sheets and render Plotly line chart
- describe setup and usage in README
- add `requirements.txt` for dependencies

## Testing
- `python -m py_compile generate_page.py`


------
https://chatgpt.com/codex/tasks/task_b_684bbf864cc8832e88ec6cca6ae17b15