### PR TITLE
Add Whisper transcription helper

### DIFF
--- a/transcribe_audio.py
+++ b/transcribe_audio.py
@@ -1,0 +1,23 @@
+import sys
+
+try:
+    import whisper
+except ImportError as e:
+    print('whisper module not installed:', e)
+    sys.exit(1)
+
+if len(sys.argv) != 3:
+    print('Usage: python transcribe_audio.py <input_mp3> <output_txt>')
+    sys.exit(1)
+
+input_file = sys.argv[1]
+output_file = sys.argv[2]
+
+model = whisper.load_model('base')
+
+print(f'Transcribing {input_file}...')
+result = model.transcribe(input_file)
+
+with open(output_file, 'w', encoding='utf-8') as f:
+    f.write(result['text'])
+print(f'Transcription saved to {output_file}')


### PR DESCRIPTION
## Summary
- add helper script `transcribe_audio.py` for converting mp3s to text using `whisper`

## Testing
- `pytest -q`
- `python transcribe_audio.py A5AmE_b68cg.mp3 output.txt` *(fails: `whisper` module missing)*

------
https://chatgpt.com/codex/tasks/task_b_68521501aff4832e9589ce81f207c851